### PR TITLE
fix: admob_storeのProvider設定をkeepAliveに修正

### DIFF
--- a/apps/app/lib/features/_advertisement/3_store/admob_store.dart
+++ b/apps/app/lib/features/_advertisement/3_store/admob_store.dart
@@ -42,7 +42,7 @@ class AdBannerStoreState with _$AdBannerStoreState {
   }) = _AdBannerStoreState;
 }
 
-@riverpod
+@Riverpod(keepAlive: true)
 class AdBannerStore extends _$AdBannerStore {
   late final AdMobService _adMobService;
 

--- a/apps/app/lib/features/_advertisement/3_store/admob_store.g.dart
+++ b/apps/app/lib/features/_advertisement/3_store/admob_store.g.dart
@@ -6,12 +6,12 @@ part of 'admob_store.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$adBannerStoreHash() => r'5574d4b8944e51e88100fe67b5fb0ef0015c38f4';
+String _$adBannerStoreHash() => r'b737b823b33ff17f58b9cfbad230767c9ecc0b03';
 
 /// See also [AdBannerStore].
 @ProviderFor(AdBannerStore)
 final adBannerStoreProvider =
-    AutoDisposeNotifierProvider<AdBannerStore, AdBannerStoreState>.internal(
+    NotifierProvider<AdBannerStore, AdBannerStoreState>.internal(
       AdBannerStore.new,
       name: r'adBannerStoreProvider',
       debugGetCreateSourceHash:
@@ -22,6 +22,6 @@ final adBannerStoreProvider =
       allTransitiveDependencies: null,
     );
 
-typedef _$AdBannerStore = AutoDisposeNotifier<AdBannerStoreState>;
+typedef _$AdBannerStore = Notifier<AdBannerStoreState>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/apps/app/lib/features/record_items/5_view_model/record_items_list_view_model.dart
+++ b/apps/app/lib/features/record_items/5_view_model/record_items_list_view_model.dart
@@ -22,35 +22,33 @@ class RecordItemsListPageState with _$RecordItemsListPageState {
 @riverpod
 class RecordItemsListViewModel extends _$RecordItemsListViewModel {
   StreamSubscription<List<RecordItem>>? _subscription;
-  
+
   @override
   RecordItemsListPageState build() {
     // ディスポーズ時にStreamをクリーンアップ
     ref.onDispose(() {
       _subscription?.cancel();
     });
-    
+
     // 認証状態を監視
     final authAsync = ref.watch(authStoreProvider);
-    
+
     // 初期状態
     var recordItemsAsync = const AsyncValue<List<RecordItem>>.loading();
-    
+
     // 認証状態に応じて記録項目を監視
     authAsync.whenData((authState) {
       if (authState != null) {
         // 既存のsubscriptionをキャンセル
         _subscription?.cancel();
-        
+
         // 新しいStreamを監視
         final repository = ref.watch(recordItemRepositoryProvider);
         final stream = repository.watchByUserId(authState.uid);
-        
+
         _subscription = stream.listen(
           (items) {
-            state = state.copyWith(
-              recordItemsAsync: AsyncValue.data(items),
-            );
+            state = state.copyWith(recordItemsAsync: AsyncValue.data(items));
           },
           onError: (error, stack) {
             state = state.copyWith(
@@ -62,10 +60,13 @@ class RecordItemsListViewModel extends _$RecordItemsListViewModel {
         recordItemsAsync = const AsyncValue.data([]);
       }
     });
-    
+
     // エラー状態の処理
     if (authAsync.hasError) {
-      recordItemsAsync = AsyncValue.error(authAsync.error!, authAsync.stackTrace!);
+      recordItemsAsync = AsyncValue.error(
+        authAsync.error!,
+        authAsync.stackTrace!,
+      );
     }
 
     return RecordItemsListPageState(


### PR DESCRIPTION
## Summary
admob_storeのProvider設定をガイドラインに準拠するよう修正

## Changes
- `@riverpod`を`@Riverpod(keepAlive: true)`に変更
- Store層はグローバル/Feature間共有状態を管理するため基本的にkeepAliveであるべき

## Context
以前の会話で「abmob featureはまだ開発途中なので、最適ではないですが、keepAliveであるべきだと思います」との合意がありました。

## Test plan
- [x] `make gen`でコード生成
- [x] `make check-all`でエラーがないことを確認
- [x] `make test`ですべてのテストが成功することを確認